### PR TITLE
use instead of jshint -> jscs

### DIFF
--- a/gulp_tasks/jshint.js
+++ b/gulp_tasks/jshint.js
@@ -1,6 +1,8 @@
 var gulp    = require('gulp'),
     jshint  = require('gulp-jshint'),
-    plumber = require('gulp-plumber');
+    jscs = require('gulp-jscs'),
+    plumber = require('gulp-plumber'),
+    stylish = require('gulp-jscs-stylish');
 
 var hintPath = [
     './client/scripts/**/*.js',
@@ -11,7 +13,9 @@ gulp.task('jshint', function() {
     return gulp.src(hintPath)
         .pipe(plumber())
         .pipe(jshint())
-        .pipe(jshint.reporter());
+        .pipe(jscs())
+        .pipe(stylish())
+        .pipe(stylish.combineWithHintResults());
 });
 
 gulp.task('watch-jshint', function() {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "gulp-angular-templatecache": "^1.5.0",
     "gulp-clean": "^0.3.1",
     "gulp-connect": "^2.2.0",
+    "gulp-jscs": "^2.0.0",
+    "gulp-jscs-stylish": "^1.1.2",
     "gulp-jshint": "^1.9.4",
     "gulp-minify-html": "^0.1.8",
     "gulp-plumber": "~1.0.0",
@@ -40,6 +42,6 @@
   },
   "dependencies": {
     "bower": "^1.4.1",
-    "gulp": "^3.9.0"
+    "gulp": "^3.9.0",
   }
 }


### PR DESCRIPTION
Now when you run "gulp jshint" - code style will not fire. 
Checking styles move from jshint to jscs (https://github.com/jscs-dev/node-jscs/issues/102). 
After that commit when run "gulp jshint" will be many style checking errors.
